### PR TITLE
feat: Make Eksekuter stateless #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,5 @@ In case you prefer an object oriented method, you can also use the `Eksekuter` c
 # With eksek
 eksek 'echo Hello' { 'This goes to stdin.' }
 # With Eksekuter
-Eksekuter.new('echo Hello').run { 'This goes to stdin.' }
+Eksekuter.new.run('echo Hello') { 'This goes to stdin.' }
 ```

--- a/lib/eksek.rb
+++ b/lib/eksek.rb
@@ -9,7 +9,7 @@ module Kernel
   private
 
   def eksek *args, **opts, &block
-    Eksekuter.new(*args, **opts).run(&block)
+    Eksekuter.new.run(*args, **opts, &block)
   end
 
   def eksek! *args, **opts, &block

--- a/spec/eksek_result_spec.rb
+++ b/spec/eksek_result_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'eksekuter'
+
+RSpec.describe 'EksekResult#to_s' do
+  it 'returns the stdout' do
+    command = 'echo HelloStdout && echo HelloStderr >&2'
+    output = "The output was: #{Eksekuter.new.run(command)}."
+    expect(output).to eq('The output was: HelloStdout.')
+  end
+end


### PR DESCRIPTION
- Makes Eksekuter stateless and moves parameters from `initialize` to `run`.
- Adds the `logger` argument to the initializer.
- Separates the one tiny `EksekResult` test to another spec.