### PR TITLE
Update rubocop dependency to strenghen security

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.3'
   s.add_development_dependency 'rspec','~> 3'
-  s.add_development_dependency 'rubocop', '~> 0'
+  s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'bundler', '~> 1.0'
 end


### PR DESCRIPTION
In our required rubocop version there's a security vulnerability and it's recommended to require at least `0.49.0`.